### PR TITLE
Updated link to OwlCarousel2 docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,7 +255,7 @@ nav {
               <ul>
                 <li>Font Awesome: <a href="http://fontawesome.io/license">http://fontawesome.io/license</a> (Font: SIL OFL 1.1, CSS: MIT License)</li>
                 <li>Bootstrap: <a href="http://getbootstrap.com">http://getbootstrap.com</a> | <a href="https://github.com/twbs/bootstrap/blob/master/LICENSE">https://github.com/twbs/bootstrap/blob/master/LICENSE</a> (Code licensed under MIT documentation under CC BY 3.0.)</li>
-                <li>Owl Carousel 2: <a href="http://www.owlcarousel.owlgraphic.com/">http://www.owlcarousel.owlgraphic.com/</a> | <a href="https://github.com/smashingboxes/OwlCarousel2/blob/develop/LICENSE">https://github.com/smashingboxes/OwlCarousel2/blob/develop/LICENSE</a> (Code licensed under MIT)
+                <li>Owl Carousel 2: <a href="https://owlcarousel2.github.io/OwlCarousel2/">https://owlcarousel2.github.io/OwlCarousel2/</a> | <a href="https://github.com/smashingboxes/OwlCarousel2/blob/develop/LICENSE">https://github.com/smashingboxes/OwlCarousel2/blob/develop/LICENSE</a> (Code licensed under MIT)
                 and of course</li>
                 <li>jQuery: <a href="https://jquery.org">https://jquery.org</a> | (Code licensed under MIT)</li>
                 <li>WP Bootstrap Navwalker by Edward McIntyre: <a href="https://github.com/twittem/wp-bootstrap-navwalker">https://github.com/twittem/wp-bootstrap-navwalker</a> | GNU GPL</li>


### PR DESCRIPTION
The old domain has expired and is being used for malicious purposes. See the [OwlCarousel2 GitHub page](https://github.com/OwlCarousel2/OwlCarousel2/blob/develop/README.md) for details.